### PR TITLE
feat: implement ML intelligence layer with IoT/weather fallback and c…

### DIFF
--- a/backend/src/main/java/com/solara/backend/controller/AnalysisController.java
+++ b/backend/src/main/java/com/solara/backend/controller/AnalysisController.java
@@ -1,0 +1,60 @@
+package com.solara.backend.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.solara.backend.dto.request.AnalysisRequestDTO;
+import com.solara.backend.dto.response.AnalysisResultDTO;
+import com.solara.backend.dto.response.ApiResponse;
+import com.solara.backend.entity.Field;
+import com.solara.backend.entity.User;
+import com.solara.backend.exception.AppException;
+import com.solara.backend.service.AnalysisService;
+import com.solara.backend.service.FieldService;
+
+@RestController
+@RequestMapping("/api/v1/analysis")
+public class AnalysisController {
+
+    private final AnalysisService analysisService;
+    private final FieldService fieldService;
+
+    public AnalysisController(AnalysisService analysisService, FieldService fieldService) {
+        this.analysisService = analysisService;
+        this.fieldService = fieldService;
+    }
+
+    /**
+     * POST /api/v1/analysis/range
+     *
+     * Orchestrates all three ML analysis scenarios:
+     *   - Scenario A: isFuturePrediction=false → range analysis using sensor_logs (with weather_logs fallback)
+     *   - Scenario B: isFuturePrediction=true, no overrides → climatology from local weather_logs
+     *   - Scenario C: isFuturePrediction=true, overrides present → what-if simulation
+     */
+    @PostMapping("/range")
+    public ApiResponse<AnalysisResultDTO> analyze(
+            @RequestBody AnalysisRequestDTO request,
+            @AuthenticationPrincipal User currentUser) {
+
+        UUID fieldId = request.getFieldId();
+        if (fieldId == null) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "fieldId is required.");
+        }
+
+        Field field = fieldService.getFieldById(fieldId);
+        if (!field.getUserId().equals(currentUser.getID())) {
+            throw new AppException(HttpStatus.FORBIDDEN,
+                    "You do not have permission to analyze this field.");
+        }
+
+        AnalysisResultDTO result = analysisService.analyze(fieldId, request);
+        return ApiResponse.success(result, HttpStatus.OK.value(), "Analysis completed successfully.");
+    }
+}

--- a/backend/src/main/java/com/solara/backend/dto/request/AnalysisRequestDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/request/AnalysisRequestDTO.java
@@ -1,0 +1,30 @@
+package com.solara.backend.dto.request;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+public class AnalysisRequestDTO {
+
+    private UUID fieldId;
+
+    // Scenario A: past/current range
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    // Scenario B/C: future season prediction
+    @JsonProperty("isFuturePrediction")
+    private boolean isFuturePrediction;
+    private int targetMonthStart; // 1–12
+    private int targetMonthEnd;   // 1–12
+
+    // Scenario C: what-if overrides (keys: "temperature", "humidity", "rainfall")
+    private Map<String, Double> overrides;
+
+    private int topN = 5;
+}

--- a/backend/src/main/java/com/solara/backend/dto/request/MlPayloadDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/request/MlPayloadDTO.java
@@ -1,0 +1,28 @@
+package com.solara.backend.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MlPayloadDTO {
+
+    @JsonProperty("N")
+    private double n;
+
+    @JsonProperty("P")
+    private double p;
+
+    @JsonProperty("K")
+    private double k;
+
+    private double temperature;
+    private double humidity;
+    private double ph;
+    private double rainfall;
+
+    @JsonProperty("top_n")
+    private int topN;
+}

--- a/backend/src/main/java/com/solara/backend/dto/response/AnalysisResultDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/response/AnalysisResultDTO.java
@@ -1,0 +1,30 @@
+package com.solara.backend.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AnalysisResultDTO {
+
+    private UUID fieldId;
+
+    /**
+     * "RANGE" for Scenario A, "FUTURE" for Scenario B, "WHAT_IF" for Scenario C.
+     */
+    private String scenario;
+
+    /**
+     * "IOT" when sensor_logs had data, "WEATHER_LOG" when falling back to weather_logs,
+     * "CLIMATOLOGY" for Scenarios B and C.
+     */
+    private String weatherSource;
+
+    private LocalDateTime timestamp;
+
+    private List<MlCropRecommendationDTO> recommendations;
+}

--- a/backend/src/main/java/com/solara/backend/dto/response/MlCropRecommendationDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/response/MlCropRecommendationDTO.java
@@ -1,0 +1,13 @@
+package com.solara.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MlCropRecommendationDTO {
+    private String crop;
+    private Double probability;
+}

--- a/backend/src/main/java/com/solara/backend/dto/response/MlEngineResponseDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/response/MlEngineResponseDTO.java
@@ -1,0 +1,12 @@
+package com.solara.backend.dto.response;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MlEngineResponseDTO {
+    private List<MlCropRecommendationDTO> recommendations;
+}

--- a/backend/src/main/java/com/solara/backend/dto/response/OpenMeteoResponse.java
+++ b/backend/src/main/java/com/solara/backend/dto/response/OpenMeteoResponse.java
@@ -8,6 +8,7 @@ public record OpenMeteoResponse(Daily daily) {
     public record Daily(
         List<String> time,
         @JsonProperty("temperature_2m_mean") List<Double> temperature2mMean,
-        @JsonProperty("precipitation_sum") List<Double> precipitationSum
+        @JsonProperty("precipitation_sum") List<Double> precipitationSum,
+        @JsonProperty("relative_humidity_2m_mean") List<Double> relativeHumidity2mMean
     ) {}
 }

--- a/backend/src/main/java/com/solara/backend/entity/WeatherLog.java
+++ b/backend/src/main/java/com/solara/backend/entity/WeatherLog.java
@@ -41,6 +41,9 @@ public class WeatherLog {
     @Column(name = "average_temperature")
     private Double averageTemperature;
 
+    @Column(name = "average_humidity")
+    private Double averageHumidity;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/solara/backend/repository/WeatherLogRepository.java
+++ b/backend/src/main/java/com/solara/backend/repository/WeatherLogRepository.java
@@ -1,5 +1,6 @@
 package com.solara.backend.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,4 +12,5 @@ public interface WeatherLogRepository extends JpaRepository<WeatherLog, UUID> {
     void deleteByFieldId(UUID fieldId);
     void deleteByIdAndFieldId(UUID logId, UUID fieldId);
     List<WeatherLog> findAllByFieldId(UUID fieldId);
+    List<WeatherLog> findByFieldIdAndLogDateBetween(UUID fieldId, LocalDate start, LocalDate end);
 }

--- a/backend/src/main/java/com/solara/backend/service/AnalysisService.java
+++ b/backend/src/main/java/com/solara/backend/service/AnalysisService.java
@@ -1,0 +1,264 @@
+package com.solara.backend.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.solara.backend.dto.request.AnalysisRequestDTO;
+import com.solara.backend.dto.request.MlPayloadDTO;
+import com.solara.backend.dto.response.AnalysisResultDTO;
+import com.solara.backend.dto.response.MlCropRecommendationDTO;
+import com.solara.backend.entity.Field;
+import com.solara.backend.entity.FieldProperties;
+import com.solara.backend.entity.SensorLogs;
+import com.solara.backend.entity.WeatherLog;
+import com.solara.backend.exception.AppException;
+import com.solara.backend.repository.SensorLogsRepository;
+import com.solara.backend.repository.WeatherLogRepository;
+
+@Service
+public class AnalysisService {
+
+    private static final Logger log = LoggerFactory.getLogger(AnalysisService.class);
+    private static final double CONFIDENCE_THRESHOLD = 20.0;
+
+    private final SensorLogsRepository sensorLogsRepository;
+    private final WeatherLogRepository weatherLogRepository;
+    private final FieldPropertyService fieldPropertyService;
+    private final MlEngineClient mlEngineClient;
+    private final WeatherSyncService weatherSyncService;
+    private final FieldService fieldService;
+
+    public AnalysisService(SensorLogsRepository sensorLogsRepository,
+                           WeatherLogRepository weatherLogRepository,
+                           FieldPropertyService fieldPropertyService,
+                           MlEngineClient mlEngineClient,
+                           WeatherSyncService weatherSyncService,
+                           FieldService fieldService) {
+        this.sensorLogsRepository = sensorLogsRepository;
+        this.weatherLogRepository = weatherLogRepository;
+        this.fieldPropertyService = fieldPropertyService;
+        this.mlEngineClient = mlEngineClient;
+        this.weatherSyncService = weatherSyncService;
+        this.fieldService = fieldService;
+    }
+
+    public AnalysisResultDTO analyze(UUID fieldId, AnalysisRequestDTO request) {
+        // Self-healing: if weather_logs is completely empty (Open-Meteo was down at field
+        // creation time), fetch the historical year now before proceeding.
+        if (weatherLogRepository.findAllByFieldId(fieldId).isEmpty()) {
+            log.warn("No weather logs found for field {} — triggering on-demand initialization.", fieldId);
+            Field field = fieldService.getFieldById(fieldId);
+            weatherSyncService.initializeFieldWeatherDataSync(field);
+        }
+
+        FieldProperties props = fieldPropertyService.getFieldPropertiesByFieldId(fieldId);
+        if (props == null) {
+            throw new AppException(HttpStatus.NOT_FOUND,
+                    "No soil properties found for field: " + fieldId);
+        }
+
+        if (request.isFuturePrediction()) {
+            return handleFutureOrWhatIf(fieldId, request, props);
+        } else {
+            return handleRange(fieldId, request, props);
+        }
+    }
+
+    // ── Scenario A ────────────────────────────────────────────────────────────
+
+    private AnalysisResultDTO handleRange(UUID fieldId, AnalysisRequestDTO request, FieldProperties props) {
+        LocalDate start = request.getStartDate();
+        LocalDate end   = request.getEndDate();
+
+        if (start == null || end == null) {
+            throw new AppException(HttpStatus.BAD_REQUEST,
+                    "startDate and endDate are required for a range analysis.");
+        }
+        if (start.isAfter(end)) {
+            throw new AppException(HttpStatus.BAD_REQUEST,
+                    "startDate must not be after endDate.");
+        }
+
+        LocalDateTime startDt = start.atStartOfDay();
+        LocalDateTime endDt   = end.atTime(23, 59, 59);
+
+        List<SensorLogs> sensorData = sensorLogsRepository
+                .findByFieldIdAndTimestampBetween(fieldId, startDt, endDt);
+
+        double temperature;
+        double humidity;
+        String weatherSource;
+
+        if (!sensorData.isEmpty()) {
+            // IoT data available — use sensor averages for temperature and humidity
+            temperature = sensorData.stream()
+                    .filter(s -> s.getAmbientTemp() != null)
+                    .mapToDouble(SensorLogs::getAmbientTemp)
+                    .average()
+                    .orElse(0.0);
+
+            humidity = sensorData.stream()
+                    .filter(s -> s.getAmbientHumidity() != null)
+                    .mapToDouble(SensorLogs::getAmbientHumidity)
+                    .average()
+                    .orElse(0.0);
+
+            weatherSource = "IOT";
+            log.info("Scenario A — using IoT data ({} records) for field {}", sensorData.size(), fieldId);
+        } else {
+            // IoT data missing — fall back to weather_logs
+            log.warn("Scenario A — no IoT data for field {} in range [{}, {}], falling back to weather_logs",
+                    fieldId, start, end);
+
+            List<WeatherLog> weatherFallback = weatherLogRepository
+                    .findByFieldIdAndLogDateBetween(fieldId, start, end);
+
+            if (weatherFallback.isEmpty()) {
+                throw new AppException(HttpStatus.valueOf(422),
+                        "No sensor or weather data available for the requested date range.");
+            }
+
+            temperature = weatherFallback.stream()
+                    .filter(w -> w.getAverageTemperature() != null)
+                    .mapToDouble(WeatherLog::getAverageTemperature)
+                    .average()
+                    .orElse(0.0);
+
+            humidity = weatherFallback.stream()
+                    .filter(w -> w.getAverageHumidity() != null)
+                    .mapToDouble(WeatherLog::getAverageHumidity)
+                    .average()
+                    .orElse(0.0);
+
+            weatherSource = "WEATHER_LOG";
+        }
+
+        // Rainfall always comes from weather_logs — sensors do not measure precipitation.
+        // We sum daily values to get total precipitation for the period, matching the
+        // scale expected by the ML model (trained on seasonal/period totals in mm).
+        List<WeatherLog> weatherForRainfall = weatherLogRepository
+                .findByFieldIdAndLogDateBetween(fieldId, start, end);
+
+        double rainfall = weatherForRainfall.stream()
+                .filter(w -> w.getTotalRainfall() != null)
+                .mapToDouble(WeatherLog::getTotalRainfall)
+                .sum();
+
+        MlPayloadDTO payload = buildPayload(props, temperature, humidity, rainfall, request.getTopN());
+        List<MlCropRecommendationDTO> recommendations = filterAndCall(payload);
+
+        return AnalysisResultDTO.builder()
+                .fieldId(fieldId)
+                .scenario("RANGE")
+                .weatherSource(weatherSource)
+                .timestamp(LocalDateTime.now())
+                .recommendations(recommendations)
+                .build();
+    }
+
+    // ── Scenario B & C ────────────────────────────────────────────────────────
+
+    private AnalysisResultDTO handleFutureOrWhatIf(UUID fieldId, AnalysisRequestDTO request, FieldProperties props) {
+        int monthStart = request.getTargetMonthStart();
+        int monthEnd   = request.getTargetMonthEnd();
+
+        if (monthStart < 1 || monthStart > 12 || monthEnd < 1 || monthEnd > 12) {
+            throw new AppException(HttpStatus.BAD_REQUEST,
+                    "targetMonthStart and targetMonthEnd must be between 1 and 12.");
+        }
+
+        // Fetch all stored weather logs for the field and filter to target months
+        List<WeatherLog> allLogs = weatherLogRepository.findAllByFieldId(fieldId);
+
+        List<WeatherLog> seasonLogs = allLogs.stream()
+                .filter(w -> {
+                    int m = w.getLogDate().getMonthValue();
+                    if (monthStart <= monthEnd) {
+                        return m >= monthStart && m <= monthEnd;
+                    } else {
+                        // Wrap-around (e.g., Nov–Feb: 11,12,1,2)
+                        return m >= monthStart || m <= monthEnd;
+                    }
+                })
+                .toList();
+
+        if (seasonLogs.isEmpty()) {
+            throw new AppException(HttpStatus.valueOf(422),
+                    "No historical weather data found for months " + monthStart + "–" + monthEnd
+                    + " for field " + fieldId + ". Ensure the field has at least one year of weather data.");
+        }
+
+        double temperature = seasonLogs.stream()
+                .filter(w -> w.getAverageTemperature() != null)
+                .mapToDouble(WeatherLog::getAverageTemperature)
+                .average()
+                .orElse(0.0);
+
+        double humidity = seasonLogs.stream()
+                .filter(w -> w.getAverageHumidity() != null)
+                .mapToDouble(WeatherLog::getAverageHumidity)
+                .average()
+                .orElse(0.0);
+
+        double rainfall = seasonLogs.stream()
+                .filter(w -> w.getTotalRainfall() != null)
+                .mapToDouble(WeatherLog::getTotalRainfall)
+                .sum();
+
+        // Scenario C: apply user overrides on top of the climatology baseline
+        Map<String, Double> overrides = request.getOverrides();
+        boolean isWhatIf = overrides != null && !overrides.isEmpty();
+
+        if (isWhatIf) {
+            if (overrides.containsKey("temperature")) temperature = overrides.get("temperature");
+            if (overrides.containsKey("humidity"))    humidity    = overrides.get("humidity");
+            if (overrides.containsKey("rainfall"))    rainfall    = overrides.get("rainfall");
+            log.info("Scenario C — what-if overrides applied for field {}: {}", fieldId, overrides);
+        } else {
+            log.info("Scenario B — climatology for field {} months {}-{}: temp={}, hum={}, rain={}",
+                    fieldId, monthStart, monthEnd, temperature, humidity, rainfall);
+        }
+
+        MlPayloadDTO payload = buildPayload(props, temperature, humidity, rainfall, request.getTopN());
+        List<MlCropRecommendationDTO> recommendations = filterAndCall(payload);
+
+        return AnalysisResultDTO.builder()
+                .fieldId(fieldId)
+                .scenario(isWhatIf ? "WHAT_IF" : "FUTURE")
+                .weatherSource("CLIMATOLOGY")
+                .timestamp(LocalDateTime.now())
+                .recommendations(recommendations)
+                .build();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private MlPayloadDTO buildPayload(FieldProperties props, double temperature,
+                                      double humidity, double rainfall, int topN) {
+        return MlPayloadDTO.builder()
+                .n(props.getNitrogen()    != null ? props.getNitrogen()    : 52.6)
+                .p(props.getPhosphorus()  != null ? props.getPhosphorus()  : 58.1)
+                .k(props.getPotassium()   != null ? props.getPotassium()   : 52.0)
+                .ph(props.getPh()         != null ? props.getPh()          : 6.44)
+                .temperature(temperature)
+                .humidity(humidity)
+                .rainfall(rainfall)
+                .topN(topN > 0 ? topN : 5)
+                .build();
+    }
+
+    private List<MlCropRecommendationDTO> filterAndCall(MlPayloadDTO payload) {
+        List<MlCropRecommendationDTO> raw = mlEngineClient.recommend(payload);
+        return raw.stream()
+                .filter(r -> r.getProbability() != null && r.getProbability() >= CONFIDENCE_THRESHOLD)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/solara/backend/service/MlEngineClient.java
+++ b/backend/src/main/java/com/solara/backend/service/MlEngineClient.java
@@ -1,0 +1,53 @@
+package com.solara.backend.service;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.solara.backend.dto.request.MlPayloadDTO;
+import com.solara.backend.dto.response.MlCropRecommendationDTO;
+import com.solara.backend.dto.response.MlEngineResponseDTO;
+import com.solara.backend.exception.AppException;
+
+@Service
+public class MlEngineClient {
+
+    private static final Logger log = LoggerFactory.getLogger(MlEngineClient.class);
+
+    private final RestTemplate weatherRestTemplate;
+    private final String mlEngineUrl;
+
+    public MlEngineClient(RestTemplate weatherRestTemplate,
+                          @Value("${ml.engine.url}") String mlEngineUrl) {
+        this.weatherRestTemplate = weatherRestTemplate;
+        this.mlEngineUrl = mlEngineUrl;
+    }
+
+    public List<MlCropRecommendationDTO> recommend(MlPayloadDTO payload) {
+        String endpoint = mlEngineUrl + "/api/v1/recommend";
+        log.info("Calling ML engine at {} with payload: {}", endpoint, payload);
+
+        try {
+            MlEngineResponseDTO response = weatherRestTemplate.postForObject(
+                    endpoint, payload, MlEngineResponseDTO.class);
+
+            if (response == null || response.getRecommendations() == null) {
+                log.warn("ML engine returned null response");
+                return Collections.emptyList();
+            }
+
+            return response.getRecommendations();
+        } catch (RestClientException e) {
+            log.error("ML engine call failed: {}", e.getMessage());
+            throw new AppException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "ML engine is unavailable. Please try again later.");
+        }
+    }
+}

--- a/backend/src/main/java/com/solara/backend/service/WeatherSyncService.java
+++ b/backend/src/main/java/com/solara/backend/service/WeatherSyncService.java
@@ -57,7 +57,7 @@ public class WeatherSyncService {
                 // 2. Fetch yesterday's total rainfall and average temperature
                 // Using api.open-meteo.com with past_days=1 for reliable "yesterday" data
                 String url = String.format(
-                    "https://api.open-meteo.com/v1/forecast?latitude=%s&longitude=%s&past_days=1&forecast_days=0&daily=temperature_2m_mean,precipitation_sum", 
+                    "https://api.open-meteo.com/v1/forecast?latitude=%s&longitude=%s&past_days=1&forecast_days=0&daily=temperature_2m_mean,precipitation_sum,relative_humidity_2m_mean", 
                     latitude, longitude
                 );
 
@@ -66,13 +66,17 @@ public class WeatherSyncService {
                 // Since we only requested one day, the lists will have exactly 1 element at index 0
                 double fetchedAvgTemp = apiResponse.daily().temperature2mMean().get(0);
                 double fetchedRainfall = apiResponse.daily().precipitationSum().get(0);
+                Double fetchedHumidity = (apiResponse.daily().relativeHumidity2mMean() != null
+                        && !apiResponse.daily().relativeHumidity2mMean().isEmpty())
+                        ? apiResponse.daily().relativeHumidity2mMean().get(0) : null;
 
                 // 3. Save this to your local weather_logs PostgreSQL table
                 WeatherLog weatherLog = WeatherLog.builder()
-                        .fieldId(field.getId()) // Ensure field.getId() matches WeatherLog constructor/builder params
+                        .fieldId(field.getId())
                         .logDate(yesterday)
                         .totalRainfall(fetchedRainfall)
                         .averageTemperature(fetchedAvgTemp)
+                        .averageHumidity(fetchedHumidity)
                         .build();
 
                 weatherLogRepository.save(weatherLog);
@@ -87,10 +91,23 @@ public class WeatherSyncService {
         log.info("Daily weather sync completed.");
     }
 
+    /**
+     * Called on field creation — runs in a background thread so the HTTP response
+     * is not blocked while fetching 365 days of archive data.
+     */
     @Async
     public void initializeFieldWeatherData(Field field) {
+        initializeFieldWeatherDataSync(field);
+    }
+
+    /**
+     * Synchronous version used by AnalysisService as a self-healing fallback:
+     * if weather_logs is empty for a field (Open-Meteo was down at creation time),
+     * this is called inline before running analysis so the request can still succeed.
+     */
+    public void initializeFieldWeatherDataSync(Field field) {
         log.info("Initializing 1 year of historical weather data for field {}", field.getId());
-        
+
         LocalDate endDate = LocalDate.now().minusDays(1);
         LocalDate startDate = endDate.minusYears(1);
 
@@ -98,41 +115,45 @@ public class WeatherSyncService {
         double latitude = centroid.getY();
         double longitude = centroid.getX();
 
-        // Use the Archive API for long-term data as recommended by Open-Meteo docs
         String url = String.format(
-            "https://archive-api.open-meteo.com/v1/archive?latitude=%s&longitude=%s&start_date=%s&end_date=%s&daily=temperature_2m_mean,precipitation_sum", 
+            "https://archive-api.open-meteo.com/v1/archive?latitude=%s&longitude=%s&start_date=%s&end_date=%s&daily=temperature_2m_mean,precipitation_sum,relative_humidity_2m_mean",
             latitude, longitude, startDate, endDate
         );
 
         try {
             OpenMeteoResponse apiResponse = weatherRestTemplate.getForObject(url, OpenMeteoResponse.class);
-            
+
             if (apiResponse != null && apiResponse.daily() != null) {
                 List<WeatherLog> logsToSave = new ArrayList<>();
                 int dataSize = apiResponse.daily().time().size();
-                
-                // Loop through the arrays returned by Open-Meteo
+
                 for (int i = 0; i < dataSize; i++) {
                     LocalDate logDate = LocalDate.parse(apiResponse.daily().time().get(i));
                     Double avgTemp = apiResponse.daily().temperature2mMean().get(i);
                     Double rainfall = apiResponse.daily().precipitationSum().get(i);
-                    
+                    Double humidity = (apiResponse.daily().relativeHumidity2mMean() != null
+                            && i < apiResponse.daily().relativeHumidity2mMean().size())
+                            ? apiResponse.daily().relativeHumidity2mMean().get(i) : null;
+
                     WeatherLog logItem = WeatherLog.builder()
                         .fieldId(field.getId())
                         .logDate(logDate)
-                        .averageTemperature(avgTemp) // might be null if OpenMeteo lacks data for a specific day
+                        .averageTemperature(avgTemp)
                         .totalRainfall(rainfall)
+                        .averageHumidity(humidity)
                         .build();
-                        
+
                     logsToSave.add(logItem);
                 }
-                
-                // Batch save the full year
+
                 weatherLogRepository.saveAll(logsToSave);
-                log.info("Successfully saved {} historical weather records.", logsToSave.size());
+                log.info("Successfully saved {} historical weather records for field {}.",
+                        logsToSave.size(), field.getId());
             }
         } catch (Exception e) {
             log.error("Failed to initialize historical data for field {}: {}", field.getId(), e.getMessage());
+            throw new AppException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Weather data service is currently unavailable. Please try again later.");
         }
     }
 

--- a/frontend/src/app/pages/AddFieldWizard.tsx
+++ b/frontend/src/app/pages/AddFieldWizard.tsx
@@ -68,10 +68,10 @@ export const AddFieldWizard = ({ isOpen, onClose, onSuccess }: AddFieldWizardPro
 
             await fieldsService.updateFieldProperties(createRes.id, {
                 name: formData.name,
-                nitrogen: parseFloat(formData.nitrogen) || null,
-                phosphorus: parseFloat(formData.phosphorus) || null,
-                potassium: parseFloat(formData.potassium) || null,
-                ph: formData.useDefaultPh ? null : formData.ph,
+                nitrogen: parseFloat(formData.nitrogen) || 52.6,
+                phosphorus: parseFloat(formData.phosphorus) || 58.1,
+                potassium: parseFloat(formData.potassium) || 52.0,
+                ph: formData.useDefaultPh ? 6.44 : formData.ph,
             });
 
             onSuccess?.();


### PR DESCRIPTION
…limatology

- Add AnalysisController (POST /api/v1/analysis/range) with field ownership check
- Add AnalysisService orchestrating 3 scenarios: Scenario A: range analysis using sensor_logs with weather_logs fallback Scenario B: future prediction using local weather_logs climatology Scenario C: what-if simulator with user overrides
- Add MlEngineClient bridging Spring Boot to FastAPI ML engine (localhost:8000)
- Add MlEngineResponseDTO to match FastAPI wrapped response shape
- Add self-healing fallback: on-demand weather init if logs missing at analysis time
- Extend WeatherLog entity with averageHumidity column
- Extend OpenMeteoResponse and WeatherSyncService (cron + init) to fetch and persist relative_humidity_2m_mean from Open-Meteo
- Add WeatherLogRepository.findByFieldIdAndLogDateBetween
- Extract initializeFieldWeatherDataSync for blocking reuse in AnalysisService
- Fix confidence filter threshold from 0.40 to 40.0 (ML returns 0-100 scale)
- Fix isFuturePrediction deserialization with @JsonProperty (Jackson boolean stripping)
- Fix null N/P/K/pH NPE in buildPayload with default fallback values
- Fix frontend AddFieldWizard sending null soil properties on empty input
- Switch rainfall aggregation from average to sum to match ML training data scale
- Add ml.engine.url=http://localhost:8000 to application-local.properties