### PR TITLE
feat(iot): implement physical ESP device registry and admin dashboard

### DIFF
--- a/backend/src/main/java/com/solara/backend/controller/EspDeviceAdminController.java
+++ b/backend/src/main/java/com/solara/backend/controller/EspDeviceAdminController.java
@@ -1,0 +1,70 @@
+package com.solara.backend.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.solara.backend.dto.request.EspDeviceDTO;
+import com.solara.backend.dto.response.ApiResponse;
+import com.solara.backend.dto.response.EspDeviceResponseDTO;
+import com.solara.backend.service.EspDeviceService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/admin/devices")
+public class EspDeviceAdminController {
+
+    private final EspDeviceService espDeviceService;
+
+    public EspDeviceAdminController(EspDeviceService espDeviceService) {
+        this.espDeviceService = espDeviceService;
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public ApiResponse<List<EspDeviceResponseDTO>> getAllDevices() {
+        return ApiResponse.success(espDeviceService.getAllDevices(), HttpStatus.OK.value(), "IoT devices retrieved successfully.");
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ApiResponse<EspDeviceResponseDTO> createDevice(@Valid @RequestBody EspDeviceDTO deviceDTO) {
+        return ApiResponse.success(espDeviceService.createDevice(deviceDTO), HttpStatus.CREATED.value(), "IoT device registered successfully.");
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}")
+    public ApiResponse<EspDeviceResponseDTO> updateDevice(@PathVariable("id") UUID id, @Valid @RequestBody EspDeviceDTO deviceDTO) {
+        return ApiResponse.success(espDeviceService.updateDevice(id, deviceDTO), HttpStatus.OK.value(), "IoT device updated successfully.");
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteDevice(@PathVariable("id") UUID id) {
+        espDeviceService.deleteDevice(id);
+        return ApiResponse.success(null, HttpStatus.OK.value(), "IoT device deleted successfully.");
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}/assign/{fieldId}")
+    public ApiResponse<EspDeviceResponseDTO> assignToField(@PathVariable("id") UUID deviceId, @PathVariable("fieldId") UUID fieldId) {
+        return ApiResponse.success(espDeviceService.assignToField(deviceId, fieldId), HttpStatus.OK.value(), "IoT device assigned to field successfully.");
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}/disconnect")
+    public ApiResponse<EspDeviceResponseDTO> disconnectFromField(@PathVariable("id") UUID deviceId) {
+        return ApiResponse.success(espDeviceService.disconnectFromField(deviceId), HttpStatus.OK.value(), "IoT device disconnected from field successfully.");
+    }
+}

--- a/backend/src/main/java/com/solara/backend/dto/request/CropDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/request/CropDTO.java
@@ -20,8 +20,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CropDTO {
-    private java.util.UUID id;
-
     private UUID id;
 
     @NotBlank(message = "Crop name is required")

--- a/backend/src/main/java/com/solara/backend/dto/request/EspDeviceDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/request/EspDeviceDTO.java
@@ -1,0 +1,20 @@
+package com.solara.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EspDeviceDTO {
+    
+    @NotBlank(message = "Serial number is required")
+    private String serialNumber;
+
+    @NotBlank(message = "Status is required")
+    private String status;
+}

--- a/backend/src/main/java/com/solara/backend/dto/response/EspDeviceResponseDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/response/EspDeviceResponseDTO.java
@@ -1,0 +1,36 @@
+package com.solara.backend.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.solara.backend.entity.EspDevice;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EspDeviceResponseDTO {
+    
+    private UUID id;
+    private String serialNumber;
+    private String status;
+    private String pairedFieldName;
+    private UUID pairedFieldId;
+    private LocalDateTime createdAt;
+    
+    public EspDeviceResponseDTO(EspDevice device) {
+        this.id = device.getId();
+        this.serialNumber = device.getSerialNumber();
+        this.status = device.getStatus();
+        if (device.getField() != null) {
+            this.pairedFieldId = device.getField().getId();
+            this.pairedFieldName = device.getField().getName();
+        }
+        this.createdAt = device.getCreatedAt();
+    }
+}

--- a/backend/src/main/java/com/solara/backend/dto/response/FieldResponseDTO.java
+++ b/backend/src/main/java/com/solara/backend/dto/response/FieldResponseDTO.java
@@ -35,7 +35,7 @@ public class FieldResponseDTO {
         this.name = field.getName();
         this.areaHa = field.getAreaHa();
         this.userId = field.getUserId();
-        this.deviceId = field.getDeviceId();
+        this.deviceId = field.getEspDevice() != null ? field.getEspDevice().getSerialNumber() : null;
         this.location = convertPolygonToCoordinates(field.getLocation());
         this.soilType = field.getSoilType();
         this.createdAt = field.getCreatedAt();

--- a/backend/src/main/java/com/solara/backend/entity/EspDevice.java
+++ b/backend/src/main/java/com/solara/backend/entity/EspDevice.java
@@ -1,0 +1,44 @@
+package com.solara.backend.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "esp_devices")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EspDevice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "serial_number", unique = true, nullable = false, length = 50)
+    private String serialNumber;
+
+    @Column(name = "status", nullable = false, length = 50)
+    private String status; // e.g., "AVAILABLE", "IN_USE", "OFFLINE"
+
+    @OneToOne(mappedBy = "espDevice")
+    private Field field;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/solara/backend/entity/Field.java
+++ b/backend/src/main/java/com/solara/backend/entity/Field.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,8 +52,9 @@ public class Field {
      * Nullable: a field may exist without a device paired to it.
      * One device can only be linked to one field (enforced in FieldService).
      */
-    @Column(name = "device_id", unique = true, length = 50)
-    private String deviceId;
+    @OneToOne(fetch = jakarta.persistence.FetchType.EAGER)
+    @jakarta.persistence.JoinColumn(name = "esp_device_id", referencedColumnName = "id", unique = true)
+    private EspDevice espDevice;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/backend/src/main/java/com/solara/backend/repository/EspDeviceRepository.java
+++ b/backend/src/main/java/com/solara/backend/repository/EspDeviceRepository.java
@@ -1,0 +1,12 @@
+package com.solara.backend.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.solara.backend.entity.EspDevice;
+
+public interface EspDeviceRepository extends JpaRepository<EspDevice, UUID> {
+    Optional<EspDevice> findBySerialNumber(String serialNumber);
+    boolean existsBySerialNumber(String serialNumber);
+}

--- a/backend/src/main/java/com/solara/backend/repository/FieldRepository.java
+++ b/backend/src/main/java/com/solara/backend/repository/FieldRepository.java
@@ -14,6 +14,6 @@ public interface FieldRepository extends  JpaRepository<Field, UUID> {
     List<Field> findByUserId(UUID userId);
 
     // Device pairing queries
-    Optional<Field> findByDeviceId(String deviceId);
-    boolean existsByDeviceId(String deviceId);
+    Optional<Field> findByEspDevice_SerialNumber(String serialNumber);
+    boolean existsByEspDevice_SerialNumber(String serialNumber);
 }

--- a/backend/src/main/java/com/solara/backend/service/DeviceMonitorService.java
+++ b/backend/src/main/java/com/solara/backend/service/DeviceMonitorService.java
@@ -42,7 +42,7 @@ public class DeviceMonitorService {
 
         // Get all fields that have a device paired
         List<Field> pairedFields = fieldRepository.findAll().stream()
-                .filter(f -> f.getDeviceId() != null && !f.getDeviceId().isBlank())
+                .filter(f -> f.getEspDevice() != null && !f.getEspDevice().getSerialNumber().isBlank())
                 .toList();
 
         for (Field field : pairedFields) {
@@ -51,7 +51,7 @@ public class DeviceMonitorService {
 
             if (!hasRecentData) {
                 log.warn("[DeviceMonitor] Field '{}' (device='{}') has been OFFLINE for 24h. Sending alert.",
-                        field.getName(), field.getDeviceId());
+                        field.getName(), field.getEspDevice().getSerialNumber());
 
                 // Send alert to the field owner
                 userRepository.findById(field.getUserId()).ifPresent(user ->
@@ -68,7 +68,7 @@ public class DeviceMonitorService {
                 + "padding: 20px; border: 1px solid #e0e0e0; border-radius: 10px;'>"
                 + "<h2 style='color: #C53030;'> Device Offline Alert</h2>"
                 + "<p>Hello,</p>"
-                + "<p>Your device <strong>" + field.getDeviceId() + "</strong> paired to field "
+                + "<p>Your device <strong>" + field.getEspDevice().getSerialNumber() + "</strong> paired to field "
                 + "<strong>" + field.getName() + "</strong> has not sent any data in the last 24 hours.</p>"
                 + "<p>Please check that your device is powered on and connected to WiFi.</p>"
                 + "<p>Thanks,<br/>The Solara Team</p>"

--- a/backend/src/main/java/com/solara/backend/service/EspDeviceService.java
+++ b/backend/src/main/java/com/solara/backend/service/EspDeviceService.java
@@ -1,0 +1,102 @@
+package com.solara.backend.service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.solara.backend.dto.request.EspDeviceDTO;
+import com.solara.backend.dto.response.EspDeviceResponseDTO;
+import com.solara.backend.entity.EspDevice;
+import com.solara.backend.exception.AppException;
+import com.solara.backend.repository.EspDeviceRepository;
+
+
+@Service
+public class EspDeviceService {
+
+    private final EspDeviceRepository espDeviceRepository;
+    private final FieldService fieldService;
+
+    public EspDeviceService(EspDeviceRepository espDeviceRepository, FieldService fieldService) {
+        this.espDeviceRepository = espDeviceRepository;
+        this.fieldService = fieldService;
+    }
+
+    public List<EspDeviceResponseDTO> getAllDevices() {
+        return espDeviceRepository.findAll()
+                .stream()
+                .map(EspDeviceResponseDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public EspDeviceResponseDTO createDevice(EspDeviceDTO dto) {
+        if (espDeviceRepository.existsBySerialNumber(dto.getSerialNumber())) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "Device with this serial number already exists.");
+        }
+
+        EspDevice device = EspDevice.builder()
+                .serialNumber(dto.getSerialNumber())
+                .status(dto.getStatus())
+                .build();
+
+        device = espDeviceRepository.save(device);
+        return new EspDeviceResponseDTO(device);
+    }
+
+    @Transactional
+    public EspDeviceResponseDTO updateDevice(UUID id, EspDeviceDTO dto) {
+        EspDevice device = espDeviceRepository.findById(id)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Device not found."));
+
+        if (!device.getSerialNumber().equals(dto.getSerialNumber()) && espDeviceRepository.existsBySerialNumber(dto.getSerialNumber())) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "Another device with this serial number already exists.");
+        }
+
+        device.setSerialNumber(dto.getSerialNumber());
+        device.setStatus(dto.getStatus());
+        device = espDeviceRepository.save(device);
+        return new EspDeviceResponseDTO(device);
+    }
+
+    @Transactional
+    public void deleteDevice(UUID id) {
+        EspDevice device = espDeviceRepository.findById(id)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Device not found."));
+
+        if (device.getField() != null) {
+            fieldService.unpairDevice(device.getField().getId());
+        }
+
+        espDeviceRepository.delete(device);
+    }
+
+    @Transactional
+    public EspDeviceResponseDTO assignToField(UUID deviceId, UUID fieldId) {
+        EspDevice device = espDeviceRepository.findById(deviceId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Device not found."));
+
+        // Use FieldService logic
+        fieldService.pairDevice(fieldId, device.getSerialNumber());
+        
+        device = espDeviceRepository.findById(deviceId).get(); // re-fetch to get mapped field
+        return new EspDeviceResponseDTO(device);
+    }
+
+    @Transactional
+    public EspDeviceResponseDTO disconnectFromField(UUID deviceId) {
+        EspDevice device = espDeviceRepository.findById(deviceId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Device not found."));
+
+        if (device.getField() != null) {
+            fieldService.unpairDevice(device.getField().getId());
+        }
+
+        device = espDeviceRepository.findById(deviceId).get();
+        return new EspDeviceResponseDTO(device);
+    }
+}

--- a/backend/src/main/java/com/solara/backend/service/FieldService.java
+++ b/backend/src/main/java/com/solara/backend/service/FieldService.java
@@ -18,10 +18,12 @@ public class FieldService {
 
     private final FieldRepository fieldRepository;
     private final WeatherSyncService weatherSyncService;
+    private final com.solara.backend.repository.EspDeviceRepository espDeviceRepository;
 
-    public FieldService(FieldRepository fieldRepo, WeatherSyncService weatherSyncService) {
+    public FieldService(FieldRepository fieldRepo, WeatherSyncService weatherSyncService, com.solara.backend.repository.EspDeviceRepository espDeviceRepository) {
         this.fieldRepository = fieldRepo;
         this.weatherSyncService = weatherSyncService;
+        this.espDeviceRepository = espDeviceRepository;
     }
 
     @Transactional
@@ -81,33 +83,36 @@ public class FieldService {
     }
 
     /**
-     * Pair a physical ESP32 device (identified by its device_id / serial number)
-     * to a field. Enforces the 1-to-1 rule: one device can only be paired to one field.
+     * Pair a physical ESP32 device (identified by its serial number)
+     * to a field. Enforces the 1-to-1 rule.
      */
     public Field pairDevice(UUID fieldId, String deviceId) {
         Field field = fieldRepository.findById(fieldId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Field not found with id: " + fieldId));
 
+        com.solara.backend.entity.EspDevice espDevice = espDeviceRepository.findBySerialNumber(deviceId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Device with serial number '" + deviceId + "' not found in registry."));
+
         // 1-to-1 check: ensure no other field already has this device
-        if (fieldRepository.existsByDeviceId(deviceId)) {
-            Field alreadyPaired = fieldRepository.findByDeviceId(deviceId).get();
+        if (fieldRepository.existsByEspDevice_SerialNumber(deviceId)) {
+            Field alreadyPaired = fieldRepository.findByEspDevice_SerialNumber(deviceId).get();
             if (!alreadyPaired.getId().equals(fieldId)) {
                 throw new AppException(HttpStatus.BAD_REQUEST,
                         "Device '" + deviceId + "' is already paired to another field.");
             }
         }
 
-        field.setDeviceId(deviceId);
+        field.setEspDevice(espDevice);
         return fieldRepository.save(field);
     }
 
     /**
-     * Remove the device pairing from a field (set device_id to null).
+     * Remove the device pairing from a field.
      */
     public Field unpairDevice(UUID fieldId) {
         Field field = fieldRepository.findById(fieldId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Field not found with id: " + fieldId));
-        field.setDeviceId(null);
+        field.setEspDevice(null);
         return fieldRepository.save(field);
     }
 }

--- a/backend/src/main/java/com/solara/backend/service/TelemetrySubscriber.java
+++ b/backend/src/main/java/com/solara/backend/service/TelemetrySubscriber.java
@@ -52,7 +52,7 @@ public class TelemetrySubscriber {
             // double batteryPct = json.has("battery_pct") ? json.get("battery_pct").asDouble() : -1;
 
             // Look up the field that has this device paired
-            Field field = fieldRepository.findByDeviceId(deviceId).orElse(null);
+            Field field = fieldRepository.findByEspDevice_SerialNumber(deviceId).orElse(null);
             if (field == null) {
                 log.warn("Received payload from unknown device_id='{}'. Pair the device to a field first.", deviceId);
                 return;

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -256,7 +256,32 @@
     "settings": "Settings",
     "admin": "Admin",
     "farmer": "Farmer",
-    "logout": "Log Out"
+    "logout": "Log Out",
+    "iot_devices": "IoT Devices"
+  },
+  "admin_devices": {
+    "title": "IoT Devices Tracker",
+    "subtitle": "Manage ESP devices across the system",
+    "delete_title": "Delete Device",
+    "delete_confirm": "Are you sure you want to delete ESP device",
+    "delete_warning": "This action cannot be undone.",
+    "cancel": "Cancel",
+    "delete_btn": "Delete",
+    "register_title": "Register New ESP Device",
+    "serial_number": "Serial Number",
+    "register_btn": "Register Device",
+    "assign_title": "Assign to Field",
+    "select_field": "Select Field (Overrides existing assigned field)",
+    "select_placeholder": "Select a field",
+    "assign_btn": "Assign",
+    "registry": "Device Registry",
+    "new_device": "Register New Device",
+    "no_devices": "No IoT Devices registered yet.",
+    "tracking": "Tracking",
+    "available": "Available - Not paired",
+    "disconnect": "Disconnect",
+    "assign_field": "Assign Field",
+    "owner_id": "Owner ID"
   },
   "admin_crop_guides": {
     "title": "Crop Guide Admin",

--- a/frontend/public/locales/tr/translation.json
+++ b/frontend/public/locales/tr/translation.json
@@ -256,7 +256,32 @@
     "settings": "Ayarlar",
     "admin": "Yönetici",
     "farmer": "Çiftçi",
-    "logout": "Oturumu Kapat"
+    "logout": "Oturumu Kapat",
+    "iot_devices": "IoT Cihazları"
+  },
+  "admin_devices": {
+    "title": "IoT Cihaz Takibi",
+    "subtitle": "Sistem genelindeki ESP cihazlarını yönetin",
+    "delete_title": "Cihazı Sil",
+    "delete_confirm": "ESP cihazını silmek istediğinize emin misiniz:",
+    "delete_warning": "Bu işlem geri alınamaz.",
+    "cancel": "İptal",
+    "delete_btn": "Sil",
+    "register_title": "Yeni ESP Cihazı Kaydet",
+    "serial_number": "Seri Numarası",
+    "register_btn": "Cihazı Kaydet",
+    "assign_title": "Tarlaya Ata",
+    "select_field": "Tarla Seçin (Mevcut atamayı geçersiz kılar)",
+    "select_placeholder": "Bir tarla seçin",
+    "assign_btn": "Ata",
+    "registry": "Cihaz Kayıtları",
+    "new_device": "Yeni Cihaz Kaydet",
+    "no_devices": "Henüz kayıtlı IoT cihazı yok.",
+    "tracking": "Takip Ediyor",
+    "available": "Boşta - Eşleştirilmemiş",
+    "disconnect": "Bağlantıyı Kes",
+    "assign_field": "Tarlaya Ata",
+    "owner_id": "Sahip Kimliği"
   },
   "admin_crop_guides": {
     "title": "Bitki Rehberi Admin",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -13,6 +13,7 @@ import { CropGuideList } from './pages/CropGuideList'
 import { CropGuideDetails } from './pages/CropGuideDetails'
 import { CropGuideAdminList } from './pages/admin/CropGuideAdminList'
 import { CropGuideAdminEditor } from './pages/admin/CropGuideAdminEditor'
+import { EspDeviceAdminList } from './pages/admin/EspDeviceAdminList'
 
 // Protected Route Component
 const ProtectedRoute = () => {
@@ -47,6 +48,7 @@ function App() {
             <Route path="/guide" element={<CropGuideList />} />
             <Route path="/guide/:slug" element={<CropGuideDetails />} />
             <Route path="/admin/crop-guides" element={<CropGuideAdminList />} />
+            <Route path="/admin/devices" element={<EspDeviceAdminList />} />
             <Route path="/admin/crop-guides/new" element={<CropGuideAdminEditor />} />
             <Route path="/admin/crop-guides/:id/edit" element={<CropGuideAdminEditor />} />
             <Route path="/settings" element={<Settings />} />

--- a/frontend/src/app/pages/admin/EspDeviceAdminList.tsx
+++ b/frontend/src/app/pages/admin/EspDeviceAdminList.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useState } from "react";
+import { Box, Button, CloseButton, Dialog, Flex, Portal, Spinner, Text, Input } from "@chakra-ui/react";
+import { Plus, Trash2, Unplug, Link } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { DashboardLayout } from "../../../components/layout/DashboardLayout";
+import { adminDeviceService } from "../../../features/devices/adminDevice.service";
+import { fieldsService } from "../../../features/fields/fields.service";
+import type { EspDeviceResponse } from "../../../features/devices/deviceTypes";
+import type { Field } from "../../../features/fields/types";
+
+export const EspDeviceAdminList = () => {
+    const { t } = useTranslation();
+    const [items, setItems] = useState<EspDeviceResponse[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    
+    // Register Dialog
+    const [isRegisterOpen, setIsRegisterOpen] = useState(false);
+    const [newSerialNumber, setNewSerialNumber] = useState("");
+    const [isRegistering, setIsRegistering] = useState(false);
+
+    // Delete Dialog
+    const [isDeletingId, setIsDeletingId] = useState<string | null>(null);
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+    const [selectedDevice, setSelectedDevice] = useState<{ id: string; serialNumber: string } | null>(null);
+
+    // Assign Dialog
+    const [isAssignOpen, setIsAssignOpen] = useState(false);
+    const [assigningDeviceId, setAssigningDeviceId] = useState<string | null>(null);
+    const [fieldsOptions, setFieldsOptions] = useState<Field[]>([]);
+    const [selectedFieldId, setSelectedFieldId] = useState<string>("");
+    const [isAssigning, setIsAssigning] = useState(false);
+
+    const load = async () => {
+        setIsLoading(true);
+        try {
+            setItems(await adminDeviceService.list());
+        } catch (err) {
+            console.error("Failed to load device admin list", err);
+            setItems([]);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const loadFieldsForAssign = async () => {
+        try {
+            const allFields = await fieldsService.getAllFields();
+            setFieldsOptions(allFields);
+        } catch (err) {
+            console.error("Failed to load fields", err);
+        }
+    }
+
+    useEffect(() => {
+        load();
+        loadFieldsForAssign();
+    }, []);
+
+    const openDeleteDialog = (id: string, serialNumber: string) => {
+        setSelectedDevice({ id, serialNumber });
+        setIsDeleteDialogOpen(true);
+    };
+
+    const onConfirmDelete = async () => {
+        if (!selectedDevice) return;
+        setIsDeletingId(selectedDevice.id);
+        try {
+            await adminDeviceService.delete(selectedDevice.id);
+            await load();
+            setIsDeleteDialogOpen(false);
+            setSelectedDevice(null);
+        } catch (err) {
+            console.error("Failed to delete device", err);
+        } finally {
+            setIsDeletingId(null);
+        }
+    };
+
+    const onRegister = async () => {
+        if (!newSerialNumber.trim()) return;
+        setIsRegistering(true);
+        try {
+            await adminDeviceService.create({ serialNumber: newSerialNumber, status: "AVAILABLE" });
+            setNewSerialNumber("");
+            setIsRegisterOpen(false);
+            await load();
+        } catch (err) {
+            console.error("Failed to register device", err);
+        } finally {
+            setIsRegistering(false);
+        }
+    };
+
+    const onDisconnect = async (deviceId: string) => {
+        try {
+            await adminDeviceService.disconnectFromField(deviceId);
+            await load();
+        } catch (err) {
+            console.error("Failed to disconnect", err);
+        }
+    };
+
+    const openAssignDialog = (deviceId: string) => {
+        setAssigningDeviceId(deviceId);
+        setIsAssignOpen(true);
+    }
+
+    const onConfirmAssign = async () => {
+        if (!assigningDeviceId || !selectedFieldId) return;
+        setIsAssigning(true);
+        try {
+            await adminDeviceService.assignToField(assigningDeviceId, selectedFieldId);
+            setIsAssignOpen(false);
+            setAssigningDeviceId(null);
+            setSelectedFieldId("");
+            await load();
+        } catch(err) {
+             console.error("Failed to assign device", err);
+        } finally {
+             setIsAssigning(false);
+        }
+    }
+
+    return (
+        <DashboardLayout title={t("admin_devices.title")} subtitle={t("admin_devices.subtitle")}>
+            {/* Delete Dialog */}
+            <Dialog.Root role="alertdialog" open={isDeleteDialogOpen} onOpenChange={(e) => { setIsDeleteDialogOpen(e.open); if (!e.open) setSelectedDevice(null); }}>
+                <Portal>
+                    <Dialog.Backdrop bg="blackAlpha.500" />
+                    <Dialog.Positioner>
+                        <Dialog.Content>
+                            <Dialog.Header>
+                                <Dialog.Title>{t("admin_devices.delete_title")}</Dialog.Title>
+                            </Dialog.Header>
+                            <Dialog.Body>
+                                <Text>{t("admin_devices.delete_confirm")} <b>{selectedDevice?.serialNumber}</b>? {t("admin_devices.delete_warning")}</Text>
+                            </Dialog.Body>
+                            <Dialog.Footer>
+                                <Dialog.ActionTrigger asChild>
+                                    <Button variant="outline">{t("admin_devices.cancel")}</Button>
+                                </Dialog.ActionTrigger>
+                                <Button colorPalette="red" loading={isDeletingId === selectedDevice?.id} onClick={onConfirmDelete}>{t("admin_devices.delete_btn")}</Button>
+                            </Dialog.Footer>
+                            <Dialog.CloseTrigger asChild><CloseButton size="sm" /></Dialog.CloseTrigger>
+                        </Dialog.Content>
+                    </Dialog.Positioner>
+                </Portal>
+            </Dialog.Root>
+
+            {/* Register Dialog */}
+            <Dialog.Root open={isRegisterOpen} onOpenChange={(e) => setIsRegisterOpen(e.open)}>
+                <Portal>
+                    <Dialog.Backdrop bg="blackAlpha.500" />
+                    <Dialog.Positioner>
+                        <Dialog.Content>
+                            <Dialog.Header>
+                                <Dialog.Title>{t("admin_devices.register_title")}</Dialog.Title>
+                            </Dialog.Header>
+                            <Dialog.Body>
+                                <Flex direction="column" gap={4}>
+                                    <Box>
+                                        <Text fontSize="sm" fontWeight="semibold" mb={1}>{t("admin_devices.serial_number")}</Text>
+                                        <Input 
+                                            placeholder="ESP32-XXX-YYY" 
+                                            value={newSerialNumber}
+                                            onChange={(e) => setNewSerialNumber(e.target.value)} 
+                                        />
+                                    </Box>
+                                </Flex>
+                            </Dialog.Body>
+                            <Dialog.Footer>
+                                <Dialog.ActionTrigger asChild><Button variant="outline">{t("admin_devices.cancel")}</Button></Dialog.ActionTrigger>
+                                <Button colorPalette="blue" loading={isRegistering} onClick={onRegister}>{t("admin_devices.register_btn")}</Button>
+                            </Dialog.Footer>
+                            <Dialog.CloseTrigger asChild><CloseButton size="sm" /></Dialog.CloseTrigger>
+                        </Dialog.Content>
+                    </Dialog.Positioner>
+                </Portal>
+            </Dialog.Root>
+
+            {/* Assign Dialog */}
+            <Dialog.Root open={isAssignOpen} onOpenChange={(e) => setIsAssignOpen(e.open)}>
+                <Portal>
+                    <Dialog.Backdrop bg="blackAlpha.500" />
+                    <Dialog.Positioner>
+                        <Dialog.Content>
+                            <Dialog.Header>
+                                <Dialog.Title>{t("admin_devices.assign_title")}</Dialog.Title>
+                            </Dialog.Header>
+                            <Dialog.Body>
+                                <Flex direction="column" gap={4}>
+                                    <Box>
+                                        <Text fontSize="sm" fontWeight="semibold" mb={1}>{t("admin_devices.select_field")}</Text>
+                                        <select 
+                                            style={{ width: "100%", padding: "8px", border: "1px solid #ccc", borderRadius: "8px" }}
+                                            value={selectedFieldId} 
+                                            onChange={(e) => setSelectedFieldId(e.target.value)}
+                                        >
+                                            <option value="" disabled>{t("admin_devices.select_placeholder")}</option>
+                                            {fieldsOptions.map(f => (
+                                                <option key={f.id} value={f.id}>{f.name} ({t("admin_devices.owner_id")}: {f.userId})</option>
+                                            ))}
+                                        </select>
+                                    </Box>
+                                </Flex>
+                            </Dialog.Body>
+                            <Dialog.Footer>
+                                <Dialog.ActionTrigger asChild><Button variant="outline">{t("admin_devices.cancel")}</Button></Dialog.ActionTrigger>
+                                <Button colorPalette="blue" loading={isAssigning} onClick={onConfirmAssign}>{t("admin_devices.assign_btn")}</Button>
+                            </Dialog.Footer>
+                            <Dialog.CloseTrigger asChild><CloseButton size="sm" /></Dialog.CloseTrigger>
+                        </Dialog.Content>
+                    </Dialog.Positioner>
+                </Portal>
+            </Dialog.Root>
+
+            <Flex direction="column" gap={4}>
+                <Flex justify="space-between" align="center">
+                    <Text fontWeight="semibold">{t("admin_devices.registry")}</Text>
+                    <Button colorPalette="green" onClick={() => setIsRegisterOpen(true)}>
+                        <Plus size={14} />
+                        {t("admin_devices.new_device")}
+                    </Button>
+                </Flex>
+
+                {isLoading ? (
+                    <Flex minH="40vh" align="center" justify="center">
+                        <Spinner />
+                    </Flex>
+                ) : (
+                    <Flex direction="column" gap={3}>
+                        {items.length === 0 && (
+                            <Text color="gray.500" textAlign="center" mt={4}>{t("admin_devices.no_devices")}</Text>
+                        )}
+                        {items.map((item) => (
+                            <Box key={item.id} bg="white" border="1px solid" borderColor="neutral.border" borderRadius="xl" p={4}>
+                                <Flex align="center" justify="space-between" gap={4}>
+                                    <Box>
+                                        <Text fontWeight="bold">{item.serialNumber}</Text>
+                                        {item.pairedFieldName ? (
+                                            <Text color="green.600" fontSize="sm" fontWeight="medium">
+                                                {t("admin_devices.tracking")}: {item.pairedFieldName} (ID: {item.pairedFieldId})
+                                            </Text>
+                                        ) : (
+                                            <Text color="orange.500" fontSize="sm" fontWeight="medium">
+                                                {t("admin_devices.available")}
+                                            </Text>
+                                        )}
+                                    </Box>
+
+                                    <Flex gap={2}>
+                                        {item.pairedFieldName ? (
+                                            <Button size="sm" variant="outline" colorPalette="orange" onClick={() => onDisconnect(item.id)}>
+                                                <Unplug size={14} /> {t("admin_devices.disconnect")}
+                                            </Button>
+                                        ) : (
+                                            <Button size="sm" variant="outline" colorPalette="blue" onClick={() => openAssignDialog(item.id)}>
+                                                <Link size={14} /> {t("admin_devices.assign_field")}
+                                            </Button>
+                                        )}
+                                        <Button
+                                            size="sm"
+                                            colorPalette="red"
+                                            onClick={() => openDeleteDialog(item.id, item.serialNumber)}
+                                        >
+                                            <Trash2 size={14} />
+                                            {t("admin_devices.delete_btn")}
+                                        </Button>
+                                    </Flex>
+                                </Flex>
+                            </Box>
+                        ))}
+                    </Flex>
+                )}
+            </Flex>
+        </DashboardLayout>
+    );
+};

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Text, VStack, Link as ChakraLink } from "@chakra-ui/react"
-import { LayoutDashboard, MapPin, BookOpen, Settings, Sprout, LogOut } from "lucide-react"
+import { LayoutDashboard, MapPin, BookOpen, Settings, Sprout, LogOut, Radio } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Link, useLocation } from "react-router-dom"
 import { useAuth } from "../../features/auth/useAuth"
@@ -12,6 +12,7 @@ export const Sidebar = () => {
 
     const navItems = isAdmin
         ? [
+            { path: "/admin/devices", icon: Radio, label: t("sidebar.iot_devices") },
             { path: "/admin/crop-guides", icon: BookOpen, label: t("sidebar.crop_guide_admin") },
             { path: "/guide", icon: BookOpen, label: t("sidebar.guide") },
             { path: "/settings", icon: Settings, label: t("sidebar.settings") },

--- a/frontend/src/features/devices/adminDevice.service.ts
+++ b/frontend/src/features/devices/adminDevice.service.ts
@@ -1,0 +1,33 @@
+import api from "../../lib/axios";
+import type { EspDeviceRequest, EspDeviceResponse } from "./deviceTypes";
+
+export const adminDeviceService = {
+    list: async (): Promise<EspDeviceResponse[]> => {
+        const response = await api.get('/admin/devices');
+        return response.data.data;
+    },
+
+    create: async (data: EspDeviceRequest): Promise<EspDeviceResponse> => {
+        const response = await api.post('/admin/devices', data);
+        return response.data.data;
+    },
+
+    update: async (id: string, data: EspDeviceRequest): Promise<EspDeviceResponse> => {
+        const response = await api.put(`/admin/devices/${id}`, data);
+        return response.data.data;
+    },
+
+    delete: async (id: string): Promise<void> => {
+        await api.delete(`/admin/devices/${id}`);
+    },
+
+    assignToField: async (deviceId: string, fieldId: string): Promise<EspDeviceResponse> => {
+        const response = await api.put(`/admin/devices/${deviceId}/assign/${fieldId}`);
+        return response.data.data;
+    },
+
+    disconnectFromField: async (deviceId: string): Promise<EspDeviceResponse> => {
+        const response = await api.put(`/admin/devices/${deviceId}/disconnect`);
+        return response.data.data;
+    }
+};

--- a/frontend/src/features/devices/deviceTypes.ts
+++ b/frontend/src/features/devices/deviceTypes.ts
@@ -1,0 +1,13 @@
+export interface EspDeviceResponse {
+    id: string;
+    serialNumber: string;
+    status: string;
+    pairedFieldName?: string;
+    pairedFieldId?: string;
+    createdAt: string;
+}
+
+export interface EspDeviceRequest {
+    serialNumber: string;
+    status: string;
+}

--- a/frontend/src/features/fields/fields.service.ts
+++ b/frontend/src/features/fields/fields.service.ts
@@ -19,6 +19,12 @@ export const fieldsService = {
         return response.data.data;
     },
 
+    // Get all fields in the system (Admin only)
+    getAllFields: async (): Promise<Field[]> => {
+        const response = await api.get('/fields/all');
+        return response.data.data;
+    },
+
     // Get field by ID
     getFieldById: async (id: string): Promise<Field> => {
         const response = await api.get(`/fields/${id}`);


### PR DESCRIPTION
- Backend: Migrated Field string-based deviceId to a strongly-typed @OneToOne EspDevice relational mapping.
- Backend: Created EspDevice entity, repository, and secured EspDeviceAdminController.
- Backend: Updated FieldService, TelemetrySubscriber, and DeviceMonitorService to enforce strict physical device checking and assignment logic.
- Frontend: Built EspDeviceAdminList.tsx dashboard for registering, unpairing, and cleanly overriding assignments for physical IoT hardware.
- Frontend: Added "IoT Devices" to the Admin sidebar navigation.
- Frontend: Added extensive Turkish and English (i18n) translations for all new device management and alert modals.